### PR TITLE
Add "q" key binding for exitting the app.

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -156,7 +156,7 @@ pub fn help() -> Dialog {
 **G**:       Scroll To Bottom
 
 ## Misc
-**ZZ, Ctrl<c>**: Exit
+**q, ZZ, Ctrl<c>**: Exit
 **?**:           Toggle this help menu
 "###;
     Dialog::around(

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -538,6 +538,9 @@ impl<T: View> ViewWrapper for VimBindingsView<T> {
             _ => self.last_event = None,
         }
         match event {
+            Event::Char('q') => {
+                return EventResult::with_cb(|s| s.quit());
+            }
             Event::Char('h') => {
                 return self.view.on_event(Event::Key(Key::Left));
             }


### PR DESCRIPTION
While **ZZ** is indeed a nice vim-style key binding to exit the app, I find that **q** would be a nice addition.

The diff is simply a copy-paste of the **ZZ** key.