### PR TITLE
Reduce crate size considerably using 'include' directive in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["cli", "tui", "stackoverflow", "stackexchange"]
 categories = ["command-line-utilities"]
 authors = ["Sam Tay <sam.chong.tay@pm.me>"]
 edition = "2018"
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [badges]
 appveyor = { repository = "samtay/so", branch = "master", service = "github" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ criterion = "0.3"
 
 [[bench]]
 name = "html_parsing"
+path = "html_parsing.rs"
 harness = false
 
 [[bench]]
 name = "md_parsing"
+path = "md_parsing.rs"
 harness = false
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["cli", "tui", "stackoverflow", "stackexchange"]
 categories = ["command-line-utilities"]
 authors = ["Sam Tay <sam.chong.tay@pm.me>"]
 edition = "2018"
-include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "themes/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [badges]
 appveyor = { repository = "samtay/so", branch = "master", service = "github" }


### PR DESCRIPTION
Please let me know if there is anything else that should be included
and I am happy to make the fix.

This is the output of `cargo diet`.

```
➜  so git:(master) cargo diet
┌─────────────────────────────────────────┬─────────────┐
│ Removed File                            │ Size (Byte) │
├─────────────────────────────────────────┼─────────────┤
│ .gitignore                              │          24 │
│ test/.gitattributes                     │          30 │
│ .github/workflows/bump_brew_formula.yml │         313 │
│ themes/tomorrow.toml                    │         366 │
│ themes/tomorrow_night_80s.toml          │         378 │
│ .github/ISSUE_TEMPLATE/bug_report.md    │         487 │
│ ci/before_deploy.ps1                    │         539 │
│ ci/script.sh                            │         545 │
│ ci/before_deploy.sh                     │         631 │
│ benches/md_parsing.rs                   │         857 │
│ roadmap.md                              │        1018 │
│ themes/default.toml                     │        1344 │
│ ci/install.sh                           │        1352 │
│ .github/CONTRIBUTING.md                 │        1574 │
│ .travis.yml                             │        1867 │
│ appveyor.yml                            │        2000 │
│ TODO.md                                 │        2127 │
│ docs/install.sh                         │        2343 │
│ benches/html_parsing.rs                 │        2649 │
│ test/duckduckgo/bad-user-agent.html     │        5783 │
│ assets/logo.png                         │       39361 │
│ test/duckduckgo/tagged.html             │       71504 │
│ test/duckduckgo/exit-vim.html           │       72157 │
│ test/google/parsing-q.html              │      210638 │
│ test/google/exit-vim.html               │      219267 │
│ assets/demo.gif                         │     3776432 │
└─────────────────────────────────────────┴─────────────┘
Saved 98% or 4.4 MB in 26 files (of 4.5 MB and 46 files in entire crate)
```