### PR TITLE
Add --print flag for non-interactive stdout output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ pub struct Opts {
     pub update_sites: bool,
     pub set_api_key: Option<String>,
     pub query: Option<String>,
+    pub print: bool,
     pub config: Config,
 }
 
@@ -100,6 +101,13 @@ where
                 .hide(!config.lucky),
         )
         .arg(
+            Arg::new("print")
+                .long("print")
+                .short('p')
+                .action(ArgAction::SetTrue)
+                .help("Print answer to stdout and exit (no TUI, no interactive prompt)"),
+        )
+        .arg(
             Arg::new("query")
                 .num_args(1..)
                 .index(1)
@@ -127,11 +135,15 @@ where
         (_, true) => false,
         _ => config.lucky,
     };
+    let print = matches.get_flag("print");
+    // --print implies lucky mode (print top answer and exit)
+    let lucky = if print { true } else { lucky };
     Ok(Opts {
         list_sites: matches.get_flag("list-sites"),
         print_config_path: matches.get_flag("print-config-path"),
         update_sites: matches.get_flag("update-sites"),
         set_api_key: matches.get_one("set-api-key").cloned(),
+        print,
         query: matches
             .get_many::<String>("query")
             .map(|words| words.map(|s| s.as_str()).collect::<Vec<_>>().join(" ")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ async fn run() -> Result<Option<tui::App>> {
     let config = opts.config;
     let sites = &config.sites;
     let lucky = config.lucky;
+    let print = opts.print;
 
     // Term tools and markdown styles (outside of TUI)
     let mut term = Term::new();
@@ -80,7 +81,13 @@ async fn run() -> Result<Option<tui::App>> {
     if let Some(q) = opts.query {
         let site_map = Arc::new(ls.get_site_map(&config.sites));
         let mut search = Search::new(config.clone(), Arc::clone(&site_map), q);
-        if lucky {
+        if print {
+            // Print mode: output answer to stdout and exit immediately.
+            // No spinner, no keypress wait, no TUI — fully pipeable.
+            let lucky_answer = search.search_lucky().await?;
+            term.print(&lucky_answer.answer.body);
+            return Ok(None);
+        } else if lucky {
             // Show top answer
             let lucky_answer = Term::wrap_spinner(search.search_lucky()).await??;
             term.print(&lucky_answer.answer.body);


### PR DESCRIPTION
## Summary

Add `-p`/`--print` flag that prints the top answer to stdout and exits immediately — no spinner, no keypress prompt, no TUI. This makes `so` fully pipeable and usable from scripts, CI, and non-TTY environments (e.g., AI agents, editor plugins).

## Motivation

The `--lucky` flag already fetches the top answer, but it requires a TTY because:
1. The spinner uses `crossterm::terminal::enable_raw_mode()`
2. `Term::wait_for_key()` blocks for interactive input

This means `so --lucky "query" | head` fails with `Crossterm error: Device not configured (os error 6)`. The `--print` flag fixes this by bypassing both the spinner and the interactive prompt.

## Usage

```bash
# Print answer to stdout (no TTY needed)
so --print "how to exit vim"
so -p "rust reverse string"

# Pipe to other tools
so -p "python list comprehension" | less
so -p "git rebase" 2>/dev/null | pbcopy

# Use from scripts
ANSWER=$(so -p -e stackexchange "bash array" 2>/dev/null)
```

`--print` implies `--lucky` (it always fetches the top-voted answer).

## Changes

| File | Change |
|------|--------|
| `src/cli.rs` | Add `-p`/`--print` flag, force lucky mode when print is set |
| `src/main.rs` | Add `print` code path: search without spinner, print answer, exit |

## Test plan

- [x] `cargo test` — all 26 tests pass
- [x] `so --print -e startpage "how to exit vim"` — prints answer, exits cleanly
- [x] `so -p -e stackexchange "python list comprehension"` — works with short flag
- [x] `so -p "query" | head` — pipes correctly, no TTY error
- [x] `so --lucky "query"` — still works as before (regression)